### PR TITLE
Change requirement from ACCOUNTADMIN to SECURITYADMIN

### DIFF
--- a/setup.sql.template
+++ b/setup.sql.template
@@ -38,7 +38,7 @@ CREATE OR REPLACE TRANSIENT TABLE {SNOWFLAKE_METADATA_DATABASE}."{SNOWFLAKE_META
                                                   );
 
 
-use role ACCOUNTADMIN;
+use role SECURITYADMIN;
 create or replace role WEBHOOK_METADATA_UPDATE_ROLE;
 grant UPDATE on table {SNOWFLAKE_METADATA_DATABASE}."{SNOWFLAKE_METADATA_SCHEMA}"."WEBHOOK_LOG" to role WEBHOOK_METADATA_UPDATE_ROLE;
 create or replace user WEBHOOK_METADATA_UPDATE_user password='evwevkjwbvkjwegvwej' default_role = WEBHOOK_METADATA_UPDATE_ROLE;


### PR DESCRIPTION
Don't need ACCOUNTADMIN here, just SECURITYADMIN.  Unlikely to have any impact in real usage as the script now requires both SECURITY and SYS roles, which are both owned by ACCOUNT.  But a) it makes it easier to split into a 2-user split script where ACCOUNTADMIN isn't an option and b) ACCOUNT > (SECURITY + SYS) i.e. even if the user running the query has both SECURITY and SYS roles, they still have a smaller permission set than ACCOUNTADMIN.  This will resolve #4.